### PR TITLE
WIP: Flipper - redux m1 & Hermes

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -78,7 +78,7 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    enableHermes: false,  // clean and rebuild if changing
+    enableHermes: true,  // clean and rebuild if changing
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = HelloWorld/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -364,6 +365,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = HelloWorld/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -9,7 +9,7 @@ target 'HelloWorld' do
   use_react_native!(
     :path => config[:reactNativePath],
     # to enable hermes on iOS, change `false` to `true` and then install pods
-    :hermes_enabled => false
+    :hermes_enabled => true
   )
 
   target 'HelloWorldTests' do

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -21,9 +21,12 @@ target 'HelloWorld' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work and
   # you should disable the next line.
-  # use_flipper!()
+  use_flipper!()
 
   post_install do |installer|
     react_native_post_install(installer)
+    installer.pods_project.build_configurations.each do |config|
+      config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+    end
   end
 end

--- a/template/package.json
+++ b/template/package.json
@@ -17,6 +17,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "react": "17.0.1",
     "react-native": "0.64.1",
+    "react-native-flipper": "^0.102.0",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-reanimated": "^2.2.0",
     "react-native-safe-area-context": "^3.2.0",
@@ -25,6 +26,7 @@
     "react-native-svg": "^12.1.1",
     "react-redux": "^7.2.4",
     "redux": "^4.1.0",
+    "redux-flipper": "^2.0.0",
     "redux-saga": "^1.1.3"
   },
   "devDependencies": {

--- a/template/src/localization/en/translation.json
+++ b/template/src/localization/en/translation.json
@@ -1,5 +1,6 @@
 {
   "demoScreen": {
+    "hermesEnabled": "Hermes enabled -> {{enabled}}",
     "incrementButton": "Increment counter by 5",
     "decrementButton": "Decrement counter by 15",
     "counter": "Counter:",

--- a/template/src/redux/store.ts
+++ b/template/src/redux/store.ts
@@ -5,12 +5,19 @@ import rootSaga from './rootSaga';
 
 const sagaMiddleware = createSagaMiddleware();
 
+const middlewares = [sagaMiddleware];
+
+if (__DEV__) {
+  const createDebugger = require('redux-flipper').default;
+  middlewares.push(createDebugger());
+}
+
 const store = configureStore({
   reducer: {
     demo: demoReducer,
   },
   middleware: getDefaultMiddleware =>
-    getDefaultMiddleware({thunk: false}).concat(sagaMiddleware),
+    getDefaultMiddleware({thunk: false}).concat(middlewares),
 });
 
 sagaMiddleware.run(rootSaga);

--- a/template/src/screens/DemoScreen.tsx
+++ b/template/src/screens/DemoScreen.tsx
@@ -47,6 +47,10 @@ const DemoScreen = ({navigation, route}: DemoScreenProps) => {
   return (
     <MainScreenLayout>
       <View style={styles.demoCard}>
+        <Text style={styles.demoText}>
+          {/* @ts-ignore */}
+          Hermes Enabled?: {global.HermesInternal ? 'YES' : 'NO'}
+        </Text>
         <Button
           onPress={() => dispatch(incrementCounterBy(5))}
           title="Increment counter by 5"

--- a/template/src/screens/DemoScreen.tsx
+++ b/template/src/screens/DemoScreen.tsx
@@ -50,8 +50,10 @@ const DemoScreen = ({navigation}: DemoScreenProps) => {
     <MainScreenLayout>
       <DemoCard>
         <Text style={styles.demoText}>
-          {/* @ts-ignore */}
-          Hermes Enabled?: {global.HermesInternal ? 'YES' : 'NO'}
+          {t('demoScreen.hermesEnabled', {
+            // @ts-ignore
+            enabled: global.HermesInternal ? 'YES' : 'NO',
+          })}
         </Text>
         <Button
           onPress={() => dispatch(incrementCounterBy(5))}


### PR DESCRIPTION
It's a draft.
After excluding `arm64` architectures, the iOS reports Warning on startup:
```
RCTBridge required dispatch_sync to load RCTDevLoadingView. This may lead to deadlocks
```
Solution found on the internet, seems to work. I'm not sure why ?
I found that in stock `react_native_post_install` script, there are already lines about excluding the `arm64` architecture for any iOS Simulator. 