### PR TITLE
Upgrade flipper to 0.178.1 to make dependencies installation possible

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -28,7 +28,7 @@
     "react-i18next": "^11.11.4",
     "react-native": "0.70.3",
     "react-native-config": "^1.4.3",
-    "react-native-flipper": "^0.150.0",
+    "react-native-flipper": "^0.178.1",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-reanimated": "^2.8.0",
     "react-native-safe-area-context": "^3.2.0",


### PR DESCRIPTION
Why do we need this change:

Before:
![Screenshot 2023-03-22 at 17 31 24](https://user-images.githubusercontent.com/60060961/226940047-0a07792b-c640-4bca-b654-f0d9c88f5f39.png)

After:
![Screenshot 2023-03-22 at 17 31 37](https://user-images.githubusercontent.com/60060961/226940129-8fae08d5-ca38-4faa-9116-3e8a9c1bc4c5.png)
