### PR TITLE
fix typescript and linter warnings

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -15,6 +15,7 @@
     "start": "react-native start",
     "reconnect:android": "adb reverse tcp:8081 tcp:8081 && adb shell input text 'RR'",
     "test": "jest",
+    "typescript": "tsc -p ./tsconfig.json --pretty --noEmit --skipLibCheck",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {

--- a/template/src/@types/react-i18next.d.ts
+++ b/template/src/@types/react-i18next.d.ts
@@ -2,6 +2,6 @@ import {resources} from '@localization/i18n';
 
 declare module 'react-i18next' {
   interface CustomTypeOptions {
-    resources: typeof resources['en'];
+    resources: (typeof resources)['en'];
   }
 }

--- a/template/src/api/apiSaga.ts
+++ b/template/src/api/apiSaga.ts
@@ -51,8 +51,11 @@ export function* makeApiCall<P>(
     const json = parsedResponse as object;
     return {json, headers};
   } catch (error) {
-    console.error('[makeApiCall] Error:', error.message);
-    yield put(onError(error.message));
+    if (error instanceof Error) {
+      console.error('[makeApiCall] Error:', error.message);
+      yield put(onError(error.message));
+    }
+
     return null;
   }
 }

--- a/template/src/api/apiSaga.ts
+++ b/template/src/api/apiSaga.ts
@@ -2,6 +2,7 @@ import {API_TIMEOUT} from '@config/timing';
 import {ActionCreatorWithPayload} from '@reduxjs/toolkit';
 import tryJson from '@utils/tryJson';
 import {call, delay, put, race} from 'redux-saga/effects';
+import {getErrorMessage} from '@utils/getMessageFromError';
 
 export type SuccessResponse = {json: object; headers: Headers};
 type ApiCallResponse = Response | undefined;
@@ -51,10 +52,8 @@ export function* makeApiCall<P>(
     const json = parsedResponse as object;
     return {json, headers};
   } catch (error) {
-    if (error instanceof Error) {
-      console.error('[makeApiCall] Error:', error.message);
-      yield put(onError(error.message));
-    }
+    console.error('[makeApiCall] Error:', getErrorMessage(error));
+    yield put(onError(getErrorMessage(error)));
 
     return null;
   }

--- a/template/src/components/layouts/MainScreenLayout.tsx
+++ b/template/src/components/layouts/MainScreenLayout.tsx
@@ -2,8 +2,9 @@ import Colors from '@config/ui/colors';
 import React from 'react';
 import {ScrollView, StatusBar, StyleSheet} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
+import {FC} from '@utils/types';
 
-const MainScreenLayout: React.FC = ({children}) => {
+const MainScreenLayout: FC = ({children}) => {
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <StatusBar />

--- a/template/src/providers/StoreProvider.tsx
+++ b/template/src/providers/StoreProvider.tsx
@@ -1,8 +1,9 @@
 import store from '@redux/store';
 import React from 'react';
 import {Provider} from 'react-redux';
+import {FC} from '@utils/types';
 
-const StoreProvider: React.FC = ({children}) => {
+const StoreProvider: FC = ({children}) => {
   return <Provider store={store}>{children}</Provider>;
 };
 export default StoreProvider;

--- a/template/src/screens/DemoScreen.tsx
+++ b/template/src/screens/DemoScreen.tsx
@@ -8,10 +8,7 @@ import Colors from '@config/ui/colors';
 import useAppDispatch from '@hooks/useAppDispatch';
 import useAppSelector from '@hooks/useAppSelector';
 import {hasData} from '@models/RemoteData';
-import type {
-  RootNavigationProp,
-  RootRouteProp,
-} from '@navigation/navigators/RootStackNavigator';
+import type {RootStackScreenProps} from '@navigation/navigators/RootStackNavigator';
 import Routes from '@navigation/routes';
 import {
   decrementCounterBy,
@@ -24,8 +21,8 @@ import {
 export type DemoScreenParams = undefined;
 
 interface DemoScreenProps {
-  navigation: RootNavigationProp<Routes.DEMO_SCREEN>;
-  route: RootRouteProp<Routes.DEMO_SCREEN>;
+  navigation: RootStackScreenProps<Routes.DEMO_SCREEN>['navigation'];
+  route: RootStackScreenProps<Routes.DEMO_SCREEN>['route'];
 }
 
 const DemoScreen = ({navigation}: DemoScreenProps) => {

--- a/template/src/screens/TranslationsDemoScreen/StyledTexts.tsx
+++ b/template/src/screens/TranslationsDemoScreen/StyledTexts.tsx
@@ -1,20 +1,21 @@
 import Colors from '@config/ui/colors';
 import React from 'react';
 import {StyleSheet, Text} from 'react-native';
+import {FC} from '@utils/types';
 
-export const TitleText: React.FC = ({children}) => {
+export const TitleText: FC = ({children}) => {
   return <Text style={styles.titleText}>{children}</Text>;
 };
 
-export const DescText: React.FC = ({children}) => {
+export const DescText: FC = ({children}) => {
   return <Text style={styles.descText}>{children}</Text>;
 };
 
-export const ExampleText: React.FC = ({children}) => {
+export const ExampleText: FC = ({children}) => {
   return <Text style={styles.exampleText}>{children}</Text>;
 };
 
-export const BoldText: React.FC = ({children}) => {
+export const BoldText: FC = ({children}) => {
   return <Text style={styles.boldText}>{children}</Text>;
 };
 

--- a/template/src/screens/__tests__/demoSlice.test.ts
+++ b/template/src/screens/__tests__/demoSlice.test.ts
@@ -74,15 +74,6 @@ describe('DemoSlice', () => {
       expect(result.comic).toEqual(Loading);
     });
 
-    it('set getLatestComicAsync to Loading if there is no comic in store', () => {
-      const result = demoSlice.reducer(initialState, {
-        type: getLatestComicAsync,
-        payload: comicMockResponse,
-      });
-
-      expect(result.comic).toEqual(Loading);
-    });
-
     it('set getLatestComicAsync to Refreshing if there is already comic in store', () => {
       const newInitialState = {
         ...initialState,

--- a/template/src/utils/getMessageFromError.ts
+++ b/template/src/utils/getMessageFromError.ts
@@ -1,10 +1,10 @@
 import {ErrorWithMessage} from './types';
 
-const isHaveMessageField = (error: unknown): error is ErrorWithMessage =>
+const hasMessageField = (error: unknown): error is ErrorWithMessage =>
   typeof (error as Record<string, unknown>)?.message === 'string';
 
 const toErrorWithMessage = (maybeError: unknown): ErrorWithMessage => {
-  if (isHaveMessageField(maybeError)) {
+  if (hasMessageField(maybeError)) {
     return maybeError;
   }
 

--- a/template/src/utils/getMessageFromError.ts
+++ b/template/src/utils/getMessageFromError.ts
@@ -1,0 +1,21 @@
+import {ErrorWithMessage} from './types';
+
+const isHaveMessageField = (error: unknown): error is ErrorWithMessage =>
+  typeof (error as Record<string, unknown>)?.message === 'string';
+
+const toErrorWithMessage = (maybeError: unknown): ErrorWithMessage => {
+  if (isHaveMessageField(maybeError)) {
+    return maybeError;
+  }
+
+  try {
+    return new Error(JSON.stringify(maybeError));
+  } catch {
+    // fallback in case there's an error stringifying the maybeError
+    // like with circular references for example.
+    return new Error(String(maybeError));
+  }
+};
+
+export const getErrorMessage = (error: unknown) =>
+  toErrorWithMessage(error).message;

--- a/template/src/utils/types.ts
+++ b/template/src/utils/types.ts
@@ -1,3 +1,7 @@
 import React from 'react';
 
 export type FC<T = {}> = React.FC<React.PropsWithChildren<T>>;
+
+export type ErrorWithMessage = {
+  message: string;
+};

--- a/template/src/utils/types.ts
+++ b/template/src/utils/types.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export type FC<T = {}> = React.FC<React.PropsWithChildren<T>>;


### PR DESCRIPTION
In terms of this PR was fixed next issues:
-add command for TypeScript checks (package.json)
-fix typescript errors (Mostly errors was about React.FC which lost his 'children' prop)
-fix linter warning (duplicated test case)