### PR TITLE
React 18 ts fixes

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -40,7 +40,7 @@
     "react-native-screens": "^3.4.0",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.1",
-    "react-redux": "^7.2.4",
+    "react-redux": "^8.1.0",
     "redux": "^4.1.0",
     "redux-flipper": "^2.0.1",
     "redux-persist": "^6.0.0",
@@ -74,9 +74,6 @@
     "react-test-renderer": "18.2.0",
     "redux-saga-test-plan": "^4.0.6",
     "typescript": "4.8.4"
-  },
-  "resolutions": {
-    "@types/react": "^17"
   },
   "jest": {
     "preset": "react-native",

--- a/template/src/components/layouts/MainScreenLayout.tsx
+++ b/template/src/components/layouts/MainScreenLayout.tsx
@@ -1,10 +1,9 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import { ScrollView, StatusBar, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import Colors from '@config/ui/colors'
-import { FC } from '@utils/types'
 
-const MainScreenLayout: FC = ({ children }) => {
+const MainScreenLayout: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <StatusBar />

--- a/template/src/providers/StoreProvider.tsx
+++ b/template/src/providers/StoreProvider.tsx
@@ -1,10 +1,9 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
 import store, { persistor } from '@redux/store'
-import { FC } from '@utils/types'
 
-const StoreProvider: FC = ({ children }) => {
+const StoreProvider: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <Provider store={store}>
       <PersistGate persistor={persistor}>{children}</PersistGate>

--- a/template/src/screens/TranslationsDemoScreen/StyledTexts.tsx
+++ b/template/src/screens/TranslationsDemoScreen/StyledTexts.tsx
@@ -1,21 +1,20 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import { StyleSheet, Text } from 'react-native'
 import Colors from '@config/ui/colors'
-import { FC } from '@utils/types'
 
-export const TitleText: FC = ({ children }) => {
+export const TitleText: React.FC<PropsWithChildren> = ({ children }) => {
   return <Text style={styles.titleText}>{children}</Text>
 }
 
-export const DescText: FC = ({ children }) => {
+export const DescText: React.FC<PropsWithChildren> = ({ children }) => {
   return <Text style={styles.descText}>{children}</Text>
 }
 
-export const ExampleText: FC = ({ children }) => {
+export const ExampleText: React.FC<PropsWithChildren> = ({ children }) => {
   return <Text style={styles.exampleText}>{children}</Text>
 }
 
-export const BoldText: FC = ({ children }) => {
+export const BoldText: React.FC<PropsWithChildren> = ({ children }) => {
   return <Text style={styles.boldText}>{children}</Text>
 }
 

--- a/template/src/utils/types.ts
+++ b/template/src/utils/types.ts
@@ -1,3 +1,0 @@
-import React from 'react'
-
-export type FC<T = unknown> = React.FC<React.PropsWithChildren<T>>


### PR DESCRIPTION
### Description

This contains super simple typescript fixes. I see no point of bringing back old FC type instead of improved type that comes with React 18. (no children prop)

### Changes

- fixed FC type
- fixed react-redux / react 18 types conflicts / errors

### Demo

`yarn lint && yarn typescript` succeeds
