### PR TITLE
Adds template lockfiles and workspace data to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 .vscode/
 .idea/
 .DS_Store
+
+template/Gemfile.lock
+template/yarn.lock
+template/ios/Podfile.lock
+template/ios/HelloWorld.xcworkspace/contents.xcworkspacedata


### PR DESCRIPTION
### Description

When internal template (without generating new project) dependencies are installed to work on internal template - git comparison is showing new files, which are always generated. They can be ignored from the root `.gitignore`.

### Changes

Adds lockfiles and workspace data to root `.gitignore` (not to internal template project `template/.gitignore`)

### Considerations

None

### Demo

None